### PR TITLE
Revert "Update getmeili/meilisearch Docker tag to v1.12.0"

### DIFF
--- a/k8s/turingpi/apps/default/hoarder/app/helmrelease.yaml
+++ b/k8s/turingpi/apps/default/hoarder/app/helmrelease.yaml
@@ -101,7 +101,7 @@ spec:
           meilisearch:
             image:
               repository: getmeili/meilisearch
-              tag: "v1.12.0"
+              tag: "v1.11.1"
               pullPolicy: IfNotPresent
             env:
               MEILI_NO_ANALYTICS: "true"


### PR DESCRIPTION
Reverts bbck/homelab#501